### PR TITLE
user/crypt: Make salts of each crypt available

### DIFF
--- a/user/crypt/apr1_crypt/apr1_crypt.go
+++ b/user/crypt/apr1_crypt/apr1_crypt.go
@@ -32,12 +32,7 @@ const (
 var md5Crypt = md5_crypt.New()
 
 func init() {
-	md5Crypt.SetSalt(common.Salt{
-		MagicPrefix:   []byte(MagicPrefix),
-		SaltLenMin:    SaltLenMin,
-		SaltLenMax:    SaltLenMax,
-		RoundsDefault: RoundsDefault,
-	})
+	md5Crypt.SetSalt(GetSalt())
 }
 
 type crypter struct{ Salt common.Salt }
@@ -56,3 +51,12 @@ func (c *crypter) Verify(hashedKey string, key []byte) error {
 func (c *crypter) Cost(hashedKey string) (int, error) { return RoundsDefault, nil }
 
 func (c *crypter) SetSalt(salt common.Salt) {}
+
+func GetSalt() common.Salt {
+	return common.Salt{
+		MagicPrefix:   []byte(MagicPrefix),
+		SaltLenMin:    SaltLenMin,
+		SaltLenMax:    SaltLenMax,
+		RoundsDefault: RoundsDefault,
+	}
+}

--- a/user/crypt/md5_crypt/md5_crypt.go
+++ b/user/crypt/md5_crypt/md5_crypt.go
@@ -34,14 +34,7 @@ type crypter struct{ Salt common.Salt }
 
 // New returns a new crypt.Crypter computing the MD5-crypt password hashing.
 func New() crypt.Crypter {
-	return &crypter{
-		common.Salt{
-			MagicPrefix:   []byte(MagicPrefix),
-			SaltLenMin:    SaltLenMin,
-			SaltLenMax:    SaltLenMax,
-			RoundsDefault: RoundsDefault,
-		},
-	}
+	return &crypter{GetSalt()}
 }
 
 func (c *crypter) Generate(key, salt []byte) (string, error) {
@@ -162,3 +155,12 @@ func (c *crypter) Verify(hashedKey string, key []byte) error {
 func (c *crypter) Cost(hashedKey string) (int, error) { return RoundsDefault, nil }
 
 func (c *crypter) SetSalt(salt common.Salt) { c.Salt = salt }
+
+func GetSalt() common.Salt {
+	return common.Salt{
+		MagicPrefix:   []byte(MagicPrefix),
+		SaltLenMin:    SaltLenMin,
+		SaltLenMax:    SaltLenMax,
+		RoundsDefault: RoundsDefault,
+	}
+}

--- a/user/crypt/sha256_crypt/sha256_crypt.go
+++ b/user/crypt/sha256_crypt/sha256_crypt.go
@@ -40,16 +40,7 @@ type crypter struct{ Salt common.Salt }
 
 // New returns a new crypt.Crypter computing the SHA256-crypt password hashing.
 func New() crypt.Crypter {
-	return &crypter{
-		common.Salt{
-			MagicPrefix:   []byte(MagicPrefix),
-			SaltLenMin:    SaltLenMin,
-			SaltLenMax:    SaltLenMax,
-			RoundsDefault: RoundsDefault,
-			RoundsMin:     RoundsMin,
-			RoundsMax:     RoundsMax,
-		},
-	}
+	return &crypter{GetSalt()}
 }
 
 func (c *crypter) Generate(key, salt []byte) (string, error) {
@@ -239,3 +230,14 @@ func (c *crypter) Cost(hashedKey string) (int, error) {
 }
 
 func (c *crypter) SetSalt(salt common.Salt) { c.Salt = salt }
+
+func GetSalt() common.Salt {
+	return common.Salt{
+		MagicPrefix:   []byte(MagicPrefix),
+		SaltLenMin:    SaltLenMin,
+		SaltLenMax:    SaltLenMax,
+		RoundsDefault: RoundsDefault,
+		RoundsMin:     RoundsMin,
+		RoundsMax:     RoundsMax,
+	}
+}

--- a/user/crypt/sha512_crypt/sha512_crypt.go
+++ b/user/crypt/sha512_crypt/sha512_crypt.go
@@ -40,16 +40,7 @@ type crypter struct{ Salt common.Salt }
 
 // New returns a new crypt.Crypter computing the SHA512-crypt password hashing.
 func New() crypt.Crypter {
-	return &crypter{
-		common.Salt{
-			MagicPrefix:   []byte(MagicPrefix),
-			SaltLenMin:    SaltLenMin,
-			SaltLenMax:    SaltLenMax,
-			RoundsDefault: RoundsDefault,
-			RoundsMin:     RoundsMin,
-			RoundsMax:     RoundsMax,
-		},
-	}
+	return &crypter{GetSalt()}
 }
 
 func (c *crypter) Generate(key, salt []byte) (string, error) {
@@ -250,3 +241,14 @@ func (c *crypter) Cost(hashedKey string) (int, error) {
 }
 
 func (c *crypter) SetSalt(salt common.Salt) { c.Salt = salt }
+
+func GetSalt() common.Salt {
+	return common.Salt{
+		MagicPrefix:   []byte(MagicPrefix),
+		SaltLenMin:    SaltLenMin,
+		SaltLenMax:    SaltLenMax,
+		RoundsDefault: RoundsDefault,
+		RoundsMin:     RoundsMin,
+		RoundsMax:     RoundsMax,
+	}
+}


### PR DESCRIPTION
I found myself replicating the `common.Salt{}` initializer in my
code to call `Generate()` upon it. Instead, I thought having it
accessible and reusing it in the library itself would be better.

This is not a breaking change. I appreciate if you take a look. :)