### PR TITLE
Use defined constants to better communicate intent

### DIFF
--- a/user/crypt/sha512_crypt/sha512_crypt.go
+++ b/user/crypt/sha512_crypt/sha512_crypt.go
@@ -86,8 +86,8 @@ func (c *crypter) Generate(key, salt []byte) (string, error) {
 		salt = saltToks[2]
 	}
 
-	if len(salt) > 16 {
-		salt = salt[0:16]
+	if len(salt) > SaltLenMax {
+		salt = salt[0:SaltLenMax]
 	}
 
 	// Compute alternate SHA512 sum with input KEY, SALT, and KEY.


### PR DESCRIPTION
Using the max salt length variable better communicates the reason behind this check than the hardcoded number.